### PR TITLE
Parametriza configuración de Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,18 @@ mvn dependency:purge-local-repository clean install -U
 
 ### Configuración del servicio InciManager
 
-Configurar el puerto del servicio en el fichero: [resources/application.properties](src/main/resources/application.properties)
+Configurar los párametros necesarios en el fichero: [resources/application.properties](src/main/resources/application.properties)
 
 ~~~properties
+### Service port (default: 8091):
 server.port = 8091
+
+### Comma-separated list of host and port pairs that are the addresses of 
+### the Kafka brokers (default: localhost:9092):
+kafka.bootstrap-servers = localhost:9092
+
+### Kafka topic for incidences (default: incidence):
+kafka.topic = incidence
 ~~~
 
 ### Inicio del servicio Apache Kafka

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ server.port = 8091
 ### the Kafka brokers (default: localhost:9092):
 kafka.bootstrap-servers = localhost:9092
 
-### Kafka topic for incidences (default: incidence):
-kafka.topic = incidence
+### Kafka topic for incidences (default: incidences):
+kafka.topic = incidences
 ~~~
 
 ### Inicio del servicio Apache Kafka
@@ -197,7 +197,7 @@ La incidencias enviadas mediante Kafka pueden ser consultadas utilizando la cons
 
 ~~~batchfile
 REM Start Apache Kafka Consumer:
-start "Kafka Consumer" /D ".\bin\windows\" "kafka-console-consumer.bat" "--bootstrap-server" "localhost:9092" "--topic" "topic" "--from-beginning"
+start "Kafka Consumer" /D ".\bin\windows\" "kafka-console-consumer.bat" "--bootstrap-server" "localhost:9092" "--topic" "incidences" "--from-beginning"
 ~~~
 
 ## Como contribuir al proyecto

--- a/src/main/java/asw/inci_manager/inci_manager_gest/services/IncidenceService.java
+++ b/src/main/java/asw/inci_manager/inci_manager_gest/services/IncidenceService.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.google.gson.Gson;
@@ -24,24 +25,25 @@ public class IncidenceService {
 
 	private static final Logger logger = Logger.getLogger(IncidenceService.class);
 
+	@Value("${kafka.topic:incidences}")
+	private String kafkaTopic;
+	
 	@Autowired
 	private KafkaProducer kafkaProducer;
 
 	@Autowired
 	private IncidenceRepository incidenceRepository;
 
-	public void send(Incidence incidence) {
-		// ToDO: Incorporar un campo topic dinámico o incluirlo como propertie:
-		kafkaProducer.send("topic", new Gson().toJson(incidence));
-		logger.info("Sending incidence \"" + incidence.getIncidenceName() + "\" to topic '" + "topic" + "'");
+	public void send(Incidence incidence) {		
+		kafkaProducer.send(kafkaTopic, new Gson().toJson(incidence));
+		logger.info("Sending incidence \"" + incidence.getIncidenceName() + "\" to topic '" + kafkaTopic + "'");
 	}
 
 	public RespuestaREST send(IncidenceREST incidenceREST, Agent agent)
-		{
-			// ToDO: Incorporar un campo topic dinámico o incluirlo como propertie:
+		{			
 			if (agent != null && agent.getPassword().equals(incidenceREST.getPassword())&&incidenceREST.isCacheable()) {
-				kafkaProducer.send("topic", new Gson().toJson(incidenceREST));
-				logger.info("Sending incidence \"" + incidenceREST.getIncidenceName() + "\" to topic '" + "topic" + "'");
+				kafkaProducer.send(kafkaTopic, new Gson().toJson(incidenceREST));
+				logger.info("Sending incidence \"" + incidenceREST.getIncidenceName() + "\" to topic '" + kafkaTopic + "'");
 			return new RespuestaAddIncidenceREST(incidenceREST.getUsername(), incidenceREST.getPassword(),
 					incidenceREST.getIncidenceName(), incidenceREST.getDescription(), incidenceREST.getLocation(),
 					incidenceREST.getLabels(), incidenceREST.getCampos(), incidenceREST.getStatus(),

--- a/src/main/java/asw/inci_manager/kafka_manager/producers/KafkaProducerFactory.java
+++ b/src/main/java/asw/inci_manager/kafka_manager/producers/KafkaProducerFactory.java
@@ -2,6 +2,7 @@ package asw.inci_manager.kafka_manager.producers;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -16,6 +17,9 @@ import java.util.Map;
 @EnableKafka
 public class KafkaProducerFactory {
 
+	@Value("${kafka.bootstrap-servers:localhost:9092}")
+	private String kafkaBootstrapServers;
+	
     @Bean
     public ProducerFactory<String, String> producerFactory() {
         return new DefaultKafkaProducerFactory<>(producerConfigs());
@@ -23,9 +27,8 @@ public class KafkaProducerFactory {
 
     @Bean
     public Map<String, Object> producerConfigs() {
-        Map<String, Object> props = new HashMap<>();
-        // ToDO: Incluir URL y puerto como properties:
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        Map<String, Object> props = new HashMap<>();        
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBootstrapServers);
         props.put(ProducerConfig.RETRIES_CONFIG, 0);
         props.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);
         props.put(ProducerConfig.LINGER_MS_CONFIG, 1);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,5 +5,5 @@ server.port = 8091
 ### the Kafka brokers (default: localhost:9092):
 kafka.bootstrap-servers = localhost:9092
 
-### Kafka topic for incidences (default: incidence):
-kafka.topic = incidence
+### Kafka topic for incidences (default: incidences):
+kafka.topic = incidences

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
+### Service port (default: 8091):
 server.port = 8091
+
+### Comma-separated list of host and port pairs that are the addresses of 
+### the Kafka brokers (default: localhost:9092):
+kafka.bootstrap-servers = localhost:9092
+
+### Kafka topic for incidences (default: incidence):
+kafka.topic = incidence


### PR DESCRIPTION
Permite definir los parámetros de configuración de Kafka en la propia invocación o utilizando el contenido del fichero application.properties:

~~~batchfile
mvn spring-boot:run -Dkafka.boostrap-servers=localhost:9092 -Dkafka.topic=incidences
~~~

Vease También: Issue #47