### PR TITLE
Corrige error de conexión entre el contenedor de InciManager y Apache Kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
 								</dependsOn>
 								<wait>
 									<url>http://${docker.host.address}:${agents.server.port}</url>
-									<time>30000</time>
+									<time>90000</time>
 								</wait>
 								<log>
 									<enabled>true</enabled>
@@ -365,7 +365,7 @@
 								</dependsOn>
 								<wait>
 									<url>http://${docker.host.address}:${incimanager.server.port}</url>
-									<time>120000</time>
+									<time>90000</time>
 								</wait>
 								<log>
 									<enabled>true</enabled>


### PR DESCRIPTION
Corrige el error de conexión con el contenedor de Apache Kafka, mediante la configuración de una subred definida por el usuario que incluye la configuración de las entradas DNS necesarias para la comunicación *backend* entre contenedores utilizando los alias definidos para cada uno de ellos. Sustituye el enlace entre contenedores mediante [legacy container links](https://docs.docker.com/network/links/) (obsoletos).

Ver también: Issue #54, #46, Arquisoft/Inci_e3b_modules#5