### PR TITLE
Implementación de toda la configuración de los contenedores Docker en tiempo de invocación

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM maven:3.5-jdk-8-alpine
+VOLUME /tmp
+ADD "target/incimanager_e3b-0.0.1-SNAPSHOT.jar" "/maven/usr/share/incidashboard_e3b/incimanager_e3b.jar"
+EXPOSE 8091
+ENTRYPOINT ["/usr/bin/java" \
+			,"-Djava.security.egd=file:/dev/./urandom" \
+			,"-jar" \
+			,"/maven/usr/share/incimanager_e3b/incimanager_e3b.jar" \
+]

--- a/docker-compose.management.yml
+++ b/docker-compose.management.yml
@@ -1,0 +1,29 @@
+version: '3.6'
+
+networks:
+  backend_network:
+    external:
+      name: backend_network
+
+services:
+  pgadmin4:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: container@pgadmin.org
+      PGADMIN_DEFAULT_PASSWORD: changeit
+      PGADMIN_SERVER_NAME: pgadmin4
+    ports:
+      - "5433:80"
+    networks:
+      - backend_network
+
+  kafka-manager:
+    image: sheepkiller/kafka-manager:latest
+    ports:
+      - "9000:9000"
+    environment:
+      ZK_HOSTS: zookeeper:2181
+      APPLICATION_SECRET: changeit
+      KM_ARGS: -Djava.net.preferIPv4Stack=true
+    networks:
+      - backend_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,89 @@
+version: '3.6'
+
+networks:
+  backend_network:
+    external:
+      name: backend_network
+
+services:
+  postgres:
+    image: postgres:alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: changeit
+    ports:
+      - "5432:5432"
+    networks:
+      - backend_network
+
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+    networks:
+      - backend_network
+
+  kafka:
+    image: wurstmeister/kafka
+    environment:
+      KAFKA_LISTENERS: PLAINTEXT://:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_CREATE_TOPICS: incidences:1:1
+    ports:
+      - "9092:9092"
+    networks:
+      - backend_network
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - zookeeper
+
+  agents_e3b:
+    image: arquisoft.ddns.net/agents_e3b
+    environment:
+      SERVER_PORT: 8090
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/postgres
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: changeit
+      SPRING_DATASOURCE_DRIVERCLASSNAME: org.postgresql.Driver
+      SPRING_JPA_DATABASE_PLATFORM: org.hibernate.dialect.PostgreSQLDialect
+      SPRING_JPA_HIBERNATE_DDL_AUTO: create-drop
+      CSV_FILEPATHNAME: tipo_agentes.csv
+    ports:
+      - "8090:8090"
+    networks:
+      - backend_network
+    volumes:
+      - /tmp
+    depends_on:
+      - postgres
+
+  incimanager_e3b:
+    build:
+      context: .
+    image: arquisoft.ddns.net/incimanager_e3b
+    environment:
+      SERVER_PORT: 8091
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/postgres
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: changeit
+      SPRING_DATASOURCE_DRIVERCLASSNAME: org.postgresql.Driver
+      SPRING_JPA_DATABASE_PLATFORM: org.hibernate.dialect.PostgreSQLDialect
+      SPRING_JPA_HIBERNATE_DDL_AUTO: create-drop
+      SPRING_CLOUD_STREAM_KAFKA_BINDER_ZKNODES: zookeeper:2181
+      SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS: kafka:9092
+      KAFKA_TOPIC: incidences
+      AGENTS_SERVER_URL: http://agents_e3b:8090
+    ports:
+      - "8091:8091"
+    networks:
+      - backend_network
+    volumes:
+      - /tmp
+    depends_on:
+      - postgres
+      - zookeeper
+      - kafka
+      - agents_e3b
+

--- a/pom.xml
+++ b/pom.xml
@@ -506,6 +506,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-project-info-reports-plugin</artifactId>
+				<version>${maven-project-info-reports-plugin.version}</version>
 				<configuration>
 					<dependencyLocationsEnabled>false</dependencyLocationsEnabled>
 					<dependencyDetailsEnabled>false</dependencyDetailsEnabled>
@@ -529,12 +530,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>${maven-pmd-plugin}</version>
+				<version>${maven-pmd-plugin.version}</version>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>${cobertura-maven-plugin}</version>
+				<version>${cobertura-maven-plugin.version}</version>
 				<configuration>
 					<formats>
 						<format>html</format>

--- a/pom.xml
+++ b/pom.xml
@@ -48,21 +48,44 @@
 
 		<docker.registry.address>arquisoft.ddns.net</docker.registry.address>
 		<docker.base.image>maven:3.5-jdk-8-alpine</docker.base.image>
-		<docker.backend.network.name>backend</docker.backend.network.name>
+		<docker.backend.network.name>backend_network</docker.backend.network.name>
+
 		<postgres.docker.alias>postgres</postgres.docker.alias>
+		<postgres.docker.image>${postgres.docker.alias}:alpine</postgres.docker.image>
 		<postgres.server.port>5432</postgres.server.port>
 		<postgres.user>postgres</postgres.user>
 		<postgres.password>changeit</postgres.password>
-		<spring.datasource.url>jdbc:postgresql://${postgres.docker.alias}:${postgres.server.port}/postgres</spring.datasource.url>
+		<postgres.db>${postgres.user}</postgres.db>
+
 		<zookeeper.docker.alias>zookeeper</zookeeper.docker.alias>
+		<zookeeper.docker.image>wurstmeister/${zookeeper.docker.alias}</zookeeper.docker.image>
 		<zookeeper.server.port>2181</zookeeper.server.port>
+
 		<kafka.docker.alias>kafka</kafka.docker.alias>
+		<kafka.docker.image>wurstmeister/${kafka.docker.alias}</kafka.docker.image>
 		<kafka.server.port>9092</kafka.server.port>
+		<kafka.server.topic>incidences</kafka.server.topic>
+
 		<agents.docker.alias>agents_e3b</agents.docker.alias>
+		<agents.docker.image>${docker.registry.address}/${agents.docker.alias}</agents.docker.image>
 		<agents.server.port>8090</agents.server.port>
-		<agents.url>http://${agents.docker.alias}:${agents.server.port}</agents.url>
+		<agents.cvs.filepathname>tipo_agentes.csv</agents.cvs.filepathname>
+
 		<incimanager.docker.alias>${project.artifactId}</incimanager.docker.alias>
+		<incimanager.docker.image>${docker.registry.address}/${incimanager.docker.alias}</incimanager.docker.image>
 		<incimanager.server.port>8091</incimanager.server.port>
+
+		<server.port>${incimanager.server.port}</server.port>
+		<spring.datasource.url>jdbc:postgresql://${postgres.docker.alias}:${postgres.server.port}/${postgres.db}</spring.datasource.url>
+		<spring.datasource.username>${postgres.user}</spring.datasource.username>
+		<spring.datasource.password>${postgres.password}</spring.datasource.password>
+		<spring.datasource.driverClassName>org.postgresql.Driver</spring.datasource.driverClassName>
+		<spring.jpa.database-platform>org.hibernate.dialect.PostgreSQLDialect</spring.jpa.database-platform>
+		<spring.jpa.hibernate.ddl-auto>create-drop</spring.jpa.hibernate.ddl-auto>
+		<spring.cloud.stream.kafka.binder.zkNodes>${zookeeper.docker.alias}:${zookeeper.server.port}</spring.cloud.stream.kafka.binder.zkNodes>
+		<spring.cloud.stream.kafka.binder.brokers>${kafka.docker.alias}:${kafka.server.port}</spring.cloud.stream.kafka.binder.brokers>
+		<kafka.topic>${kafka.server.topic}</kafka.topic>
+		<agents.server.url>http://${agents.docker.alias}:${agents.server.port}</agents.server.url>
 
 		<maven.test.skip>true</maven.test.skip>
 	</properties>
@@ -190,11 +213,12 @@
 					<images>
 						<image>
 							<alias>${postgres.docker.alias}</alias>
-							<name>${postgres.docker.alias}:alpine</name>
+							<name>${postgres.docker.image}</name>
 							<run>
 								<env>
 									<POSTGRES_USER>${postgres.user}</POSTGRES_USER>
 									<POSTGRES_PASSWORD>${postgres.password}</POSTGRES_PASSWORD>
+									<POSTGRES_DB>${postgres.db}</POSTGRES_DB>
 								</env>
 								<ports>
 									<port>${postgres.server.port}:${postgres.server.port}</port>
@@ -217,7 +241,7 @@
 						</image>
 						<image>
 							<alias>${zookeeper.docker.alias}</alias>
-							<name>wurstmeister/${zookeeper.docker.alias}</name>
+							<name>${zookeeper.docker.image}</name>
 							<run>
 								<ports>
 									<port>${zookeeper.server.port}:${zookeeper.server.port}</port>
@@ -240,12 +264,13 @@
 						</image>
 						<image>
 							<alias>${kafka.docker.alias}</alias>
-							<name>wurstmeister/${kafka.docker.alias}</name>
+							<name>${kafka.docker.image}</name>
 							<run>
 								<env>
 									<KAFKA_LISTENERS>PLAINTEXT://:${kafka.server.port}</KAFKA_LISTENERS>
 									<KAFKA_ADVERTISED_LISTENERS>PLAINTEXT://${kafka.docker.alias}:${kafka.server.port}</KAFKA_ADVERTISED_LISTENERS>
 									<KAFKA_ZOOKEEPER_CONNECT>${zookeeper.docker.alias}:${zookeeper.server.port}</KAFKA_ZOOKEEPER_CONNECT>
+									<KAFKA_CREATE_TOPICS>${kafka.server.topic}:1:1</KAFKA_CREATE_TOPICS>
 								</env>
 								<ports>
 									<port>${kafka.server.port}:${kafka.server.port}</port>
@@ -276,13 +301,18 @@
 						</image>
 						<image>
 							<alias>${agents.docker.alias}</alias>
-							<name>${docker.registry.address}/${agents.docker.alias}</name>
+							<name>${agents.docker.image}</name>
 							<run>
-								<volumes>
-									<bind>
-										<volume>/tmp</volume>
-									</bind>
-								</volumes>
+								<env>
+									<SERVER_PORT>${agents.server.port}</SERVER_PORT>
+									<SPRING_DATASOURCE_URL>${spring.datasource.url}</SPRING_DATASOURCE_URL>
+									<SPRING_DATASOURCE_USERNAME>${spring.datasource.username}</SPRING_DATASOURCE_USERNAME>
+									<SPRING_DATASOURCE_PASSWORD>${spring.datasource.password}</SPRING_DATASOURCE_PASSWORD>
+									<SPRING_DATASOURCE_DRIVERCLASSNAME>${spring.datasource.driverClassName}</SPRING_DATASOURCE_DRIVERCLASSNAME>
+									<SPRING_JPA_DATABASE_PLATFORM>${spring.jpa.database-platform}</SPRING_JPA_DATABASE_PLATFORM>
+									<SPRING_JPA_HIBERNATE_DDL_AUTO>${spring.jpa.hibernate.ddl-auto}</SPRING_JPA_HIBERNATE_DDL_AUTO>
+									<CSV_FILEPATHNAME>${agents.cvs.filepathname}</CSV_FILEPATHNAME>
+								</env>
 								<ports>
 									<port>${agents.server.port}:${agents.server.port}</port>
 								</ports>
@@ -291,6 +321,11 @@
 									<name>${docker.backend.network.name}</name>
 									<alias>${agents.docker.alias}</alias>
 								</network>
+								<volumes>
+									<bind>
+										<volume>/tmp</volume>
+									</bind>
+								</volumes>
 								<dependsOn>
 									<container>${postgres.docker.alias}</container>
 								</dependsOn>
@@ -307,7 +342,7 @@
 						</image>
 						<image>
 							<alias>${incimanager.docker.alias}</alias>
-							<name>${docker.registry.address}/${incimanager.docker.alias}</name>
+							<name>${incimanager.docker.image}</name>
 							<build>
 								<from>${docker.base.image}</from>
 								<tags>
@@ -335,15 +370,22 @@
 									<arg>-Djava.security.egd=file:/dev/./urandom</arg>
 									<arg>-jar</arg>
 									<arg>/maven/usr/share/${project.artifactId}/${project.artifactId}-${project.version}.${project.packaging}</arg>
-									<arg>--spring.datasource.url=${spring.datasource.url}</arg>
-									<arg>--spring.datasource.username=${postgres.user}</arg>
-									<arg>--spring.datasource.password=${postgres.password}</arg>
-									<arg>--spring.cloud.stream.kafka.binder.brokers=${kafka.docker.alias}:${kafka.server.port}</arg>
-									<arg>--spring.cloud.stream.kafka.binder.zkNodes=${zookeeper.docker.alias}:${zookeeper.server.port}</arg>
-									<arg>--agents.url=${agents.url}</arg>
 								</entryPoint>
 							</build>
 							<run>
+								<env>
+									<SERVER_PORT>${incimanager.server.port}</SERVER_PORT>
+									<SPRING_DATASOURCE_URL>${spring.datasource.url}</SPRING_DATASOURCE_URL>
+									<SPRING_DATASOURCE_USERNAME>${spring.datasource.username}</SPRING_DATASOURCE_USERNAME>
+									<SPRING_DATASOURCE_PASSWORD>${spring.datasource.password}</SPRING_DATASOURCE_PASSWORD>
+									<SPRING_DATASOURCE_DRIVERCLASSNAME>${spring.datasource.driverClassName}</SPRING_DATASOURCE_DRIVERCLASSNAME>
+									<SPRING_JPA_DATABASE_PLATFORM>${spring.jpa.database-platform}</SPRING_JPA_DATABASE_PLATFORM>
+									<SPRING_JPA_HIBERNATE_DDL_AUTO>${spring.jpa.hibernate.ddl-auto}</SPRING_JPA_HIBERNATE_DDL_AUTO>
+									<SPRING_CLOUD_STREAM_KAFKA_BINDER_ZKNODES>${spring.cloud.stream.kafka.binder.zkNodes}</SPRING_CLOUD_STREAM_KAFKA_BINDER_ZKNODES>
+									<SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS>${spring.cloud.stream.kafka.binder.brokers}</SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS>
+									<KAFKA_TOPIC>${kafka.topic}</KAFKA_TOPIC>
+									<AGENTS_SERVER_URL>${agents.server.url}</AGENTS_SERVER_URL>
+								</env>
 								<ports>
 									<port>${incimanager.server.port}:${incimanager.server.port}</port>
 								</ports>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,19 +1,15 @@
-### Service port (default: 8091):
 server.port = 8091
-
-### Comma-separated list of brokers to which the Kafka binder will connect 
-### (default: localhost:9092):
-spring.cloud.stream.kafka.binder.brokers=localhost:9092
-
-###  Comma-separated list of ZooKeeper nodes to which the Kafka binder can connect 
-### (default: localhost:2181):
-spring.cloud.stream.kafka.binder.zkNodes=localhost:2181
-
-### Kafka topic for incidences (default: incidences):
-kafka.topic = incidences
 
 spring.datasource.url = jdbc:postgresql://localhost:5432/postgres
 spring.datasource.username=postgres
 spring.datasource.password=changeit
-spring.jpa.hibernate.ddl-auto=create-drop
 spring.datasource.driverClassName=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+
+spring.cloud.stream.kafka.binder.zkNodes=localhost:2181
+spring.cloud.stream.kafka.binder.brokers=localhost:9092
+kafka.topic = incidences
+
+agents.server.url=http://localhost:8090
+


### PR DESCRIPTION
Incluye toda la configuración de los contendedores como *properties* dentro del fichero POM, permitiendo transmitírsela en forma de variables de entorno durante el proceso de invocación (sobreescribiendo el contenido del fichero [application.properties](https://github.com/Arquisoft/InciManager_e3b/blob/master/src/main/resources/application.properties)).

Ver también: Issue #46, Arquisoft/Inci_e3b_modules#5